### PR TITLE
feat: add expo webview android app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+**/node_modules/
+android-webview/.expo/

--- a/android-webview/App.js
+++ b/android-webview/App.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { StatusBar } from 'expo-status-bar';
+import { WebView } from 'react-native-webview';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <StatusBar style="auto" />
+      <WebView source={{ uri: 'https://example.com' }} style={{ flex: 1 }} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/android-webview/README.md
+++ b/android-webview/README.md
@@ -1,0 +1,24 @@
+# Android WebView App
+
+This is a minimal [Expo](https://expo.dev/) project that wraps the existing web application in a WebView so it can be distributed as an Android APK.
+
+## Development
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm start
+   ```
+
+## Building an APK
+
+To create a production APK, install the Expo Application Services (EAS) CLI and run:
+
+```bash
+npx expo build:android --type apk
+```
+
+Replace the URL in `App.js` with the deployed address of the web application before building.

--- a/android-webview/app.json
+++ b/android-webview/app.json
@@ -1,0 +1,11 @@
+{
+  "expo": {
+    "name": "GPay Merchant WebView",
+    "slug": "gpay-merchant-webview",
+    "version": "1.0.0",
+    "android": {
+      "package": "com.example.gpaymerchantwebview",
+      "versionCode": 1
+    }
+  }
+}

--- a/android-webview/babel.config.js
+++ b/android-webview/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/android-webview/package.json
+++ b/android-webview/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "gpay-merchant-webview",
+  "version": "1.0.0",
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^51.0.0",
+    "expo-status-bar": "~1.12.0",
+    "react": "18.2.0",
+    "react-native": "0.73.2",
+    "react-native-webview": "^13.6.2"
+  }
+}


### PR DESCRIPTION
## Summary
- add Expo project that wraps site in a WebView for Android
- document development and APK build steps
- ignore node_modules in version control

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_689cec736558832aa7acd15c63e3d956